### PR TITLE
fix: scope custom SSL config to Bareun client only

### DIFF
--- a/backend/src/main/kotlin/day/widdle/widdle/correction/service/checker/BareunSpellChecker.kt
+++ b/backend/src/main/kotlin/day/widdle/widdle/correction/service/checker/BareunSpellChecker.kt
@@ -8,6 +8,7 @@ import day.widdle.widdle.correction.service.dto.bareun.CorrectErrorResponse
 import day.widdle.widdle.global.annotation.LogExternal
 import day.widdle.widdle.global.exception.WiddleException
 import day.widdle.widdle.global.support.loggerDelegate
+import io.netty.handler.ssl.SslContext
 import io.netty.handler.ssl.SslContextBuilder
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory
 import kotlinx.coroutines.reactor.awaitSingleOrNull
@@ -26,7 +27,8 @@ import reactor.netty.http.client.HttpClient
 class BareunSpellChecker(
     private val correctionProperties: CorrectionProperties,
     @param:Qualifier("postMethodWebClient") private val builder: WebClient.Builder,
-    private val env: Environment
+    private val env: Environment,
+    private val sslContext: SslContext,
 ) : KoreanSpellChecker {
 
     private val log by loggerDelegate()
@@ -68,7 +70,10 @@ class BareunSpellChecker(
 
             builder.clientConnector(ReactorClientHttpConnector(httpClient))
         } else {
-            builder
+            val httpClient = HttpClient.create()
+                .secure { t -> t.sslContext(sslContext) }
+
+            builder.clientConnector(ReactorClientHttpConnector(httpClient))
         }
     }
 

--- a/backend/src/main/kotlin/day/widdle/widdle/correction/service/checker/BareunSpellChecker.kt
+++ b/backend/src/main/kotlin/day/widdle/widdle/correction/service/checker/BareunSpellChecker.kt
@@ -59,22 +59,19 @@ class BareunSpellChecker(
 
     private fun isProfileDevThanSetSSLIgnore(builder: WebClient.Builder): WebClient.Builder {
         val isDevProfile = env.acceptsProfiles(Profiles.of("dev"))
-
-        return if (isDevProfile) {
-            val sslContext = SslContextBuilder.forClient()
+        val appliedSslContext = if (isDevProfile) {
+            val devSslContext = SslContextBuilder.forClient()
                 .trustManager(InsecureTrustManagerFactory.INSTANCE)
                 .build()
-
-            val httpClient = HttpClient.create()
-                .secure { t -> t.sslContext(sslContext) }
-
-            builder.clientConnector(ReactorClientHttpConnector(httpClient))
+            devSslContext
         } else {
-            val httpClient = HttpClient.create()
-                .secure { t -> t.sslContext(sslContext) }
-
-            builder.clientConnector(ReactorClientHttpConnector(httpClient))
+            sslContext
         }
+
+        val httpClient = HttpClient.create()
+            .secure { t -> t.sslContext(appliedSslContext) }
+
+        return builder.clientConnector(ReactorClientHttpConnector(httpClient))
     }
 
     private fun handleErrorResponse(clientResponse: ClientResponse): Mono<Throwable> =

--- a/backend/src/main/kotlin/day/widdle/widdle/global/config/WebClientConfig.kt
+++ b/backend/src/main/kotlin/day/widdle/widdle/global/config/WebClientConfig.kt
@@ -1,8 +1,8 @@
 package day.widdle.widdle.global.config
 
+import java.time.Duration
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.netty.channel.ChannelOption
-import io.netty.handler.ssl.SslContext
 import io.netty.handler.timeout.ReadTimeoutHandler
 import io.netty.handler.timeout.WriteTimeoutHandler
 import org.springframework.context.annotation.Bean
@@ -18,12 +18,10 @@ import org.springframework.util.MimeType
 import org.springframework.web.reactive.function.client.ExchangeStrategies
 import org.springframework.web.reactive.function.client.WebClient
 import reactor.netty.http.client.HttpClient
-import java.time.Duration
 
 @Configuration
 class WebClientConfig(
     private val objectMapper: ObjectMapper,
-    private val sslContext: SslContext,
 ) {
 
     private fun clientConnector() = ReactorClientHttpConnector(
@@ -34,7 +32,6 @@ class WebClientConfig(
                 c.addHandlerLast(ReadTimeoutHandler(5))
                     .addHandlerLast(WriteTimeoutHandler(5))
             }
-            .secure { it.sslContext(sslContext) }
     )
 
     @Bean


### PR DESCRIPTION
## Background

공통 `WebClient` 설정에서 커스텀 `SslContext`를 모든 외부 HTTP 클라이언트에 공통 적용하고 있었습니다. 이 SSL 설정은 원래 Bareun 클라이언트에만 필요한 설정인데, 표준국어대사전 API(`stdict.korean.go.kr`)를 포함한 다른 외부 API 호출에도 함께 적용되고 있었습니다.

## Changes
- 공통 `WebClient` 설정에서 커스텀 `SslContext` 제거
- `BareunSpellChecker`에만 커스텀 `SslContext` 적용
- `KoreanSearchApi`를 포함한 나머지 외부 호출은 기본 JVM TLS 설정 사용

## Purpose
표준국어대사전 호출 시 TLS 핸드셰이크 과정에서 간헐적으로 발생하던 `Connection reset by peer` 경고의 원인 후보 중 하나가 Bareun 전용 SSL 설정의 공통 적용이었기 때문에, 적용 범위를 명확히 분리했습니다. 최종 응답은 정상적으로 내려오더라도, 특정 클라이언트 전용 설정이 다른 외부 API 호출에 전파되는 구조는 유지하지 않는 것이 맞다고 판단했습니다.

## Validation
- 로컬 환경에서 표준국어대사전 조회 정상 동작 확인
- 로컬 환경에서 Bareun 동작 이상 없음 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **리팩터링**
  * 보안 인증서 설정 방식을 개선하여 시스템 안정성을 강화했습니다.

**변경 사항:** 내부 SSL/TLS 설정 구조를 재구성했습니다. 최종 사용자에게 직접적인 기능 변화는 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->