### PR TITLE
chore: align Docker build with Java 21 and optimize bootJar image build

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -6,8 +6,4 @@
 .vscode
 
 .gradle
-gradle
-gradlew
 gradlew.bat
-
-src

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,16 +1,23 @@
-FROM gradle:8.5-jdk21 AS build
+# syntax=docker/dockerfile:1.7
+
+FROM gradle:8.14.3-jdk21 AS build
 WORKDIR /app
-COPY build.gradle settings.gradle ./
+
+COPY build.gradle.kts settings.gradle.kts ./
 COPY gradle ./gradle
+
 COPY src ./src
-RUN gradle build -x test --no-daemon -Pspring.profiles.active=prod
+RUN --mount=type=cache,target=/home/gradle/.gradle \
+    gradle bootJar --no-daemon --max-workers=1 \
+    -Dorg.gradle.jvmargs="-Xms512m -Xmx1536m -XX:MaxMetaspaceSize=512m" \
+    -Pspring.profiles.active=prod
 
 
 # ---- Base Image ----
-FROM eclipse-temurin:17-jre-alpine
+FROM eclipse-temurin:21-jre-jammy
 WORKDIR /app
 
-RUN adduser -D appuser
+RUN useradd --create-home --shell /usr/sbin/nologin appuser
 USER appuser
 
 # ---- Application ----

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -7,7 +7,7 @@ COPY build.gradle.kts settings.gradle.kts ./
 COPY gradle ./gradle
 
 COPY src ./src
-RUN --mount=type=cache,target=/home/gradle/.gradle \
+RUN --mount=type=cache,target=/home/gradle/.gradle,sharing=locked \
     gradle bootJar --no-daemon --max-workers=1 \
     -Dorg.gradle.jvmargs="-Xms512m -Xmx1536m -XX:MaxMetaspaceSize=512m" \
     -Pspring.profiles.active=prod

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -9,8 +9,7 @@ COPY gradle ./gradle
 COPY src ./src
 RUN --mount=type=cache,target=/home/gradle/.gradle,sharing=locked \
     gradle bootJar --no-daemon --max-workers=1 \
-    -Dorg.gradle.jvmargs="-Xms512m -Xmx1536m -XX:MaxMetaspaceSize=512m" \
-    -Pspring.profiles.active=prod
+    -Dorg.gradle.jvmargs="-Xms512m -Xmx1536m -XX:MaxMetaspaceSize=512m"
 
 
 # ---- Base Image ----

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -16,7 +16,7 @@ version = "0.0.1-SNAPSHOT"
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(17)
+        languageVersion = JavaLanguageVersion.of(21)
     }
 }
 


### PR DESCRIPTION
## Summary
- Docker 빌드 경로를 Java 21 기준으로 정렬했습니다.
- 배포용 이미지 생성 시 `bootJar`를 사용하도록 변경했습니다.
- Gradle 캐시 마운트를 적용해 반복 빌드 시 소요 시간을 줄이도록 구성했습니다.
- `.dockerignore`를 정리해 Docker build context에 필요한 파일이 빠지지 않도록 수정했습니다.

## Details
- builder 이미지를 `gradle:8.14.3-jdk21`로 변경했습니다.
- runtime 이미지를 `eclipse-temurin:17-jre-alpine`에서 `eclipse-temurin:21-jre-jammy`로 변경했습니다.
- Gradle toolchain 버전을 Java 17에서 Java 21로 맞췄습니다.
- Docker 빌드 단계에서 `gradle build -x test` 대신 `gradle bootJar`를 사용하도록 변경했습니다.
- 컨테이너 환경에서 Gradle 빌드가 보다 안정적으로 동작하도록 JVM 메모리 옵션을 조정했습니다.
- Jammy 베이스 이미지에 맞게 사용자 생성 방식을 `useradd` 기준으로 변경했습니다.

## Why
기존 설정은 프로젝트의 Java 버전과 Docker 빌드/실행 환경이 서로 완전히 맞지 않았습니다. 또한 배포에 필요한 산출물보다 더 큰 범위의 빌드를 수행하고 있어 이미지 빌드 과정이 비효율적일 수 있었습니다. 이번 변경으로 배포 경로를 실제 운영 산출물 기준으로 단순화하고, Java 버전 불일치 가능성을 줄였습니다.

## Notes
- Docker 이미지 빌드 경로에서는 기존과 동일하게 테스트를 수행하지 않습니다.
- 첫 빌드는 의존성 다운로드 때문에 시간이 걸릴 수 있지만, 이후 반복 빌드에서는 Gradle 캐시 재사용 효과를 기대할 수 있습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **유지보수**
  * Java 런타임이 버전 21로 업그레이드되었습니다.
  * Docker 기반 빌드 환경과 Gradle 빌드 설정이 갱신되어 빌드 호환성과 안정성이 향상되었습니다.
  * 빌드 캐시 및 병렬성 조정으로 컨테이너 빌드 성능이 개선되었습니다.
  * 도커 무시 규칙이 변경되어 소스 디렉터리가 빌드 컨텍스트에 포함됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->